### PR TITLE
Remove override of configuration value, which is not allowed anymore …

### DIFF
--- a/packages/yarn-plugin-version-tools/sources/index.ts
+++ b/packages/yarn-plugin-version-tools/sources/index.ts
@@ -60,12 +60,6 @@ class VTCheckCommand extends VersionCheckCommand {
 
 const plugin: Plugin = {
   configuration: {
-    // @ts-ignore
-    deferredVersionFolder: {
-      description: `Folder where are stored the versioning files`,
-      type: SettingsType.ABSOLUTE_PATH,
-      default: `./.yarn/versions`
-    },
     preferDeferredVersions: {
       description: `If true, running \`yarn ${COMMAND_NS}\` will assume the \`--deferred\` flag unless \`--immediate\` is set`,
       type: SettingsType.BOOLEAN,


### PR DESCRIPTION
Otherwise `Internal Error: Cannot redefine settings "deferredVersionFolder"`.

Was this redefined on purpose?